### PR TITLE
preserve causeby in app exceptions

### DIFF
--- a/src/main/java/gov/cida/sedmap/data/Fetcher.java
+++ b/src/main/java/gov/cida/sedmap/data/Fetcher.java
@@ -386,7 +386,7 @@ public abstract class Fetcher {
 				if (nwisTriesCount == NUM_NWIS_TRIES -1) {
 					logger.error(e.getMessage());
 					logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-					throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+					throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 				}
 			}
 			nwisTriesCount++;
@@ -485,7 +485,7 @@ public abstract class Fetcher {
 					} else {
 						logger.error("Failed to fetch from the Database.  Exception is:" +  e.getMessage());
 						logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-						throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+						throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 					}
 				} finally {
 					IoUtils.quiteClose(fileData);

--- a/src/main/java/gov/cida/sedmap/data/JdbcFetcher.java
+++ b/src/main/java/gov/cida/sedmap/data/JdbcFetcher.java
@@ -379,7 +379,7 @@ public class JdbcFetcher extends Fetcher {
 			r.rs = r.ps.executeQuery();
 		} catch (SQLException e) {
 			logger.error(e);
-			throw new SedmapException(OGCExceptionCode.InvalidParameterValue, new Exception(e.getMessage()));
+			throw new SedmapException(OGCExceptionCode.InvalidParameterValue, e);
 		} catch (Exception e) {
 			logger.error(e);
 			e.printStackTrace();

--- a/src/main/java/gov/cida/sedmap/data/JdbcFetcher.java
+++ b/src/main/java/gov/cida/sedmap/data/JdbcFetcher.java
@@ -376,9 +376,11 @@ public class JdbcFetcher extends Fetcher {
 					}
 				}
 			}
+			logger.info("executeQuery: start");
 			r.rs = r.ps.executeQuery();
+			logger.info("executeQuery: finish");
 		} catch (SQLException e) {
-			logger.error(e);
+			logger.error("executeQuery: error", e);
 			throw new SedmapException(OGCExceptionCode.InvalidParameterValue, e);
 		} catch (Exception e) {
 			logger.error(e);

--- a/src/main/java/gov/cida/sedmap/io/BaseHandler.java
+++ b/src/main/java/gov/cida/sedmap/io/BaseHandler.java
@@ -44,7 +44,7 @@ public class BaseHandler implements FileDownloadHandler {
 		} catch (IOException e) {
 			logger.error(e.getMessage());
 			logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+			throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 		}
 		
 		return this; //chain
@@ -56,7 +56,7 @@ public class BaseHandler implements FileDownloadHandler {
 		} catch (IOException e) {
 			logger.error(e.getMessage());
 			logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+			throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 		}
 		
 		return this; //chain
@@ -68,7 +68,7 @@ public class BaseHandler implements FileDownloadHandler {
 		} catch (IOException e) {
 			logger.error(e.getMessage());
 			logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+			throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 		}
 		
 		return this; //chain
@@ -87,7 +87,7 @@ public class BaseHandler implements FileDownloadHandler {
 		} catch (Exception e) {
 			logger.error(e.getMessage());
 			logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+			throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 		}
 		
 		return this; //chain
@@ -121,7 +121,7 @@ public class BaseHandler implements FileDownloadHandler {
 		} catch (Exception e) {
 			logger.error(e.getMessage());
 			logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+			throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 		} finally {
 			IoUtils.quiteClose(fileData);
 		}
@@ -146,7 +146,7 @@ public class BaseHandler implements FileDownloadHandler {
 		} catch (IOException e) {
 			logger.error(e.getMessage());
 			logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+			throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 		}
 		return this; //chain
 	}

--- a/src/main/java/gov/cida/sedmap/io/EmailLinkHandler.java
+++ b/src/main/java/gov/cida/sedmap/io/EmailLinkHandler.java
@@ -47,7 +47,7 @@ public class EmailLinkHandler extends ZipHandler {
 		} catch (IOException e) {
 			logger.error(e.getMessage());
 			logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+			throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 		}
 		
 		return this; //chain
@@ -59,7 +59,7 @@ public class EmailLinkHandler extends ZipHandler {
 		} catch (IOException e) {
 			logger.error(e.getMessage());
 			logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+			throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 		}
 
 		SedmapDataMail mailer = new SedmapDataMail();

--- a/src/main/java/gov/cida/sedmap/io/TimeOutHandler.java
+++ b/src/main/java/gov/cida/sedmap/io/TimeOutHandler.java
@@ -69,7 +69,7 @@ public class TimeOutHandler extends EmailLinkHandler {
 			} catch (IOException e) {
 				logger.error(e.getMessage());
 				logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-				throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+				throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 			}
 	
 			/**

--- a/src/main/java/gov/cida/sedmap/io/ZipHandler.java
+++ b/src/main/java/gov/cida/sedmap/io/ZipHandler.java
@@ -34,7 +34,7 @@ public class ZipHandler extends BaseHandler {
 		} catch (IOException e) {
 			logger.error(e.getMessage());
 			logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+			throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 		}
 		
 		resp.addHeader("Content-Disposition", "attachment; filename=data.zip");
@@ -50,7 +50,7 @@ public class ZipHandler extends BaseHandler {
 		} catch (IOException e) {
 			logger.error(e.getMessage());
 			logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+			throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 		}
 		
 		return this; //chain
@@ -64,7 +64,7 @@ public class ZipHandler extends BaseHandler {
 		}  catch (IOException e) {
 			logger.error(e.getMessage());
 			logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+			throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 		}
 		
 		return this; //chain
@@ -79,7 +79,7 @@ public class ZipHandler extends BaseHandler {
 		}  catch (IOException e) {
 			logger.error(e.getMessage());
 			logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+			throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 		}
 		
 		return this; //chain

--- a/src/main/java/gov/cida/sedmap/ogc/OgcUtils.java
+++ b/src/main/java/gov/cida/sedmap/ogc/OgcUtils.java
@@ -85,7 +85,7 @@ public class OgcUtils {
 		} catch (Exception e) {
 			logger.error(e.getMessage());
 			logger.error("Due to internal exception caught, throwing InvalidParameterValue OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.InvalidParameterValue, new Exception("Failed to parse OGC.  " + e.getLocalizedMessage()));
+			throw new SedmapException(OGCExceptionCode.InvalidParameterValue, new Exception("Failed to parse OGC.",e));
 		}
 	}
 
@@ -119,7 +119,7 @@ public class OgcUtils {
 		} catch (FilterToSQLException e) {
 			logger.error("Failed to convert to SQL.  Exception is: " + e.getMessage());
 			logger.error("Due to internal exception caught, throwing OperationNotSupported OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.OperationNotSupported, new Exception("Failed to parse OGC.  " + e.getLocalizedMessage()));
+			throw new SedmapException(OGCExceptionCode.OperationNotSupported, new Exception("Failed to parse OGC.",e));
 		}
 
 		return sql;
@@ -177,7 +177,7 @@ public class OgcUtils {
 		} catch (Exception e) {
 			logger.error(e.getMessage());
 			logger.error("Due to internal exception caught, throwing ResourceNotFound OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.ResourceNotFound, new Exception(SedmapException.GENERIC_ERROR));
+			throw new SedmapException(OGCExceptionCode.ResourceNotFound, e);
 		}
 
 		return store;
@@ -206,7 +206,7 @@ public class OgcUtils {
 		} catch (Exception e) {
 			logger.error(e.getMessage());
 			logger.error("Due to internal exception caught, throwing generic OGC error for error handling on the client side.");
-			throw new SedmapException(OGCExceptionCode.NoApplicableCode, new Exception(SedmapException.GENERIC_ERROR));
+			throw new SedmapException(OGCExceptionCode.NoApplicableCode, e);
 		}
 		
 		return reader;


### PR DESCRIPTION
Not sure why the causeby was omitted in original code but it is not very useful to get a newly wrapped e and many times just a generic thingy.